### PR TITLE
Fix flags in README to match Makefile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ To uninstall it run:
 To use it without installing it, put the following
 lines in your sara wxprot config file::
 
-	SOURCE_PATH/bin/* mprotect,relro,verbose
-	SOURCE_PATH/bin/procattr relro,complain,verbose
-	SOURCE_PATH/bin/fake_tramp mprotect,emutramp,relro,verbose
-	SOURCE_PATH/bin/trampoline* mprotect,emutramp,relro,verbose
+	SOURCE_PATH/bin/* mprotect,verbose
+	SOURCE_PATH/bin/procattr mmap,complain,verbose
+	SOURCE_PATH/bin/fake_tramp mprotect,emutramp_or_mprotect,verbose
+	SOURCE_PATH/bin/trampoline* mprotect,emutramp_or_mprotect,verbose
 
 and then run:
 	EXTRA_BINS_PATH="." make && cd bin && ./sara-test


### PR DESCRIPTION
https://github.com/smeso/sara-test/blob/master/Makefile#L102 differ from README values. "relro" argument doesn't exist in https://github.com/smeso/saractl/blob/master/sara/submodules/wxprot.py#L124