### PR TITLE
Archlinux: add glibc dependence

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -6,6 +6,7 @@ pkgdesc="S.A.R.A.'s test suite"
 arch=('x86_64')
 url="https://github.com/smeso/sara-test"
 license=('GPL3')
+depends=('glibc')
 optdepends=('saractl')
 makedepends=('git')
 source=("git+https://github.com/smeso/sara-test.git#tag=v${pkgver}?signed")


### PR DESCRIPTION
Without libsara it needs to depend on glibc directly