### PR TITLE
Check if helper programs exist before launching the tests

### DIFF
--- a/src/sara-test.c
+++ b/src/sara-test.c
@@ -487,6 +487,12 @@ int main(int argc, char *argv[])
 	PSIZE = getpagesize();
 	setvbuf(stdout, NULL, _IOLBF, 0);
 
+	check_file_exists(TRAMPOLINE_EXEC);
+	check_file_exists(TRAMPOLINE_NOPIE_EXEC);
+	check_file_exists(TRANSFER_EXEC);
+	check_file_exists(PROCATTR_EXEC);
+	check_file_exists(FAKET_EXEC);
+
 	printf("These tests should pass even with SARA disabled:\n");
 	RUN_TEST(wx_mappings);
 	RUN_TEST(nx_shellcode);

--- a/src/utils.c
+++ b/src/utils.c
@@ -109,6 +109,14 @@ int is_w(void *m)
 	return 0;
 }
 
+int check_file_exists(const char *path)
+{
+	if (access(path, F_OK) != 0) {
+		printf("error: %s doesn't exist, check your EXTRA_BINS_PATH build variable\n", path);
+		exit(2);
+	}
+}
+
 void *do_mmap(size_t len, int prot, int flags, int fd)
 {
 	void *m = mmap(NULL, len, prot, flags, fd, 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,6 +55,7 @@ int count_wx_mappings(pid_t pid);
 int is_wx(void *m);
 int is_x(void *m);
 int is_w(void *m);
+int check_file_exists(const char *path);
 void *do_mmap(size_t len, int prot, int flags, int fd);
 void do_mprotect(const void *addr, size_t len, int prot);
 int try_wx(void *m, size_t size);


### PR DESCRIPTION
Should prevent #6

A further improvement would be to transform `EXTRA_BINS_PATH` into a CLI argument, so that the path is not hard-coded in the binary